### PR TITLE
Chris obj tf pub

### DIFF
--- a/scripts/ros_pybullet_interface_node.py
+++ b/scripts/ros_pybullet_interface_node.py
@@ -59,7 +59,7 @@ class ROSPyBulletInterface:
         self.name = rospy.get_name()
 
         # Setup
-        self.dur = rospy.Duration(DT)
+        self.dur = rospy.Duration(ROS_DT)
         self.tf_broadcaster = tf2_ros.TransformBroadcaster()
         self.tf_buffer = tf2_ros.Buffer()
         self.tf_listener = tf2_ros.TransformListener(self.tf_buffer)
@@ -67,6 +67,7 @@ class ROSPyBulletInterface:
         self.tfs = {}
         self.dynamic_collisionvisual_objects = []
         self.static_collisionvisual_objects = []
+        self.static_collision_objects = []
 
         # Initialization message
         rospy.loginfo("%s: Initializing class", self.name)
@@ -276,7 +277,7 @@ class ROSPyBulletInterface:
                 'object': obj,
                 'position': config['link_state']['position'],
                 'orientation': config['link_state']['orientation_eulerXYZ'],
-            }}
+            })
             if 'pub_tf' in config['link_state']:
                 static_col_obj['pub_tf'] = config['link_state']['pub_tf']
             else:


### PR DESCRIPTION
Solving #56. Now, when you specify a static object you can optionally specify if you want the interface to publish a tf to ROS or not (default not).

The issue is now solved, but when we do a re-vamp of the repository (discussed yesterday) we will likely need to think about how we handle when we publish object tfs.