### PR TITLE
Add is_defined method and include in rgbd sensor class

### DIFF
--- a/ros_pybullet_interface/src/rpbi/pybullet_object_pose.py
+++ b/ros_pybullet_interface/src/rpbi/pybullet_object_pose.py
@@ -50,6 +50,9 @@ class PybulletObjectPose:
         pos, rot = self.pb_obj.node.wait_for_tf('rpbi/world', self.base_tf_id, timeout=self.timeout)
         self.base = self.pb_obj.node.tf.pos_quat_to_matrix(pos, rot)
 
+    def is_defined(self):
+        return self.base is not None
+
     def get(self):
         T = self.offset @ self.base
         pos = T[:3,-1].flatten()

--- a/ros_pybullet_interface/src/rpbi/pybullet_rgbd_sensor.py
+++ b/ros_pybullet_interface/src/rpbi/pybullet_rgbd_sensor.py
@@ -79,6 +79,8 @@ class PybulletRGBDSensor(PybulletSensor):
 
     def main_loop(self, event):
 
+        if not self.pose.is_defined(): return
+
         # extrinsics
         p, q = self.pose.get()
         T = transformations.translation_matrix(p) @ transformations.quaternion_matrix(q)


### PR DESCRIPTION
This new method prevents errors being thrown when initialization hasn't finished, but timers/callbacks are running. Will need to fix #113 before merging. 