### PR TITLE
Optionally make Pybullet simulation time as ROS time

### DIFF
--- a/ros_pybullet_interface/src/rpbi/ros_node.py
+++ b/ros_pybullet_interface/src/rpbi/ros_node.py
@@ -21,6 +21,7 @@ class RosNode:
     def __init__(self, *args, **kwargs):
         rospy.init_node(*args, **kwargs)
         self.tf = TfInterface()
+        self.Time = rospy.Time
 
     def on_shutdown(self, *args, **kwargs):
         rospy.on_shutdown(*args, **kwargs)


### PR DESCRIPTION
Allow user to sync ROS time with Pybullet simulation time. The crux here is that you must set the interface to step through pybullet manually since [the simulation time is not currently exposed](https://pybullet.org/Bullet/phpBB3/viewtopic.php?t=12438&sid=af204aab8dc0d39319929ec4566fe62b).