### PR TITLE
make "visual sphere" visible in depth image

### DIFF
--- a/rpbi_examples/configs/pybullet_objects_example/visual_sphere.yaml
+++ b/rpbi_examples/configs/pybullet_objects_example/visual_sphere.yaml
@@ -3,7 +3,7 @@ name: 'visual_sphere'
 createVisualShape:
   shapeType: "GEOM_SPHERE"
   radius: 0.2
-  rgbaColor: [0.0, 1.0, 1, 0.6]
+  rgbaColor: [0.0, 1.0, 1, 1.0]
 
 object_tf:
   tf_id: "figure_eight"


### PR DESCRIPTION
It turns out that setting the alpha of an object below 1.0 makes it fully "transparent" for the depth image. I guess PyBullet cannot deal with transparent objects in the depth image.