### PR TITLE
Add header pub wrench

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 The ROS-PyBullet Interface is a framework that provides a bridge between the popular Robot Operating System (ROS) with a reliable impact/contact simulator PyBullet.
 Furthermore, this framework provides several interfaces that allow humans to interact with the simulator that facilitates Human-Robot Interaction in a virtual world.
 
+The documentation can be found [here](https://ros-pybullet.github.io/ros_pybullet_interface/).
+
 # Requirements
 
 * ROS Noetic

--- a/doc/additional_features.rst
+++ b/doc/additional_features.rst
@@ -141,7 +141,7 @@ ik_ros
   :width: 600
   :alt: Alternative text
 
-The `ik_ros <https://github.com/cmower/ik_ros>`_ package is a standardized interface for inverse kinematics using ROS.
+The `ik_ros <https://github.com/ros-pybullet/ik_ros>`_ package is a standardized interface for inverse kinematics using ROS.
 Input data (e.g. end-effector task space goals) are directed to a problem setup node, that collects the information into a single message.
 The setup node then publishes a problem message at a given frequency.
 A solver node, that interfaces via a standardized plugin to an IK solver, then solves the problem and publishes the target joint state.
@@ -149,7 +149,7 @@ A solver node, that interfaces via a standardized plugin to an IK solver, then s
 safe_robot
 ----------
 
-A low-level `ROS package <https://github.com/cmower/safe_robot>`_ for the safe operation of robots.
+A low-level `ROS package <https://github.com/ros-pybullet/safe_robot>`_ for the safe operation of robots.
 Easily setup with a single launch file.
 The ``safe_robot_node.py`` acts as a remapper.
 Target joint states are passed through several safety checks, if safe then the command is sent to the robot, otherwise they are prevented.
@@ -163,5 +163,5 @@ Possible checks
 custom_ros_tools
 ----------------
 
-The `custom_ros_tools <https://github.com/cmower/custom_ros_tools>`_ package provides a collection of generic useful tools for ROS.
+The `custom_ros_tools <https://github.com/ros-pybullet/custom_ros_tools>`_ package provides a collection of generic useful tools for ROS.
 The package is extensively used in the ROS-PyBullet Interface.

--- a/doc/communication_with_ros.rst
+++ b/doc/communication_with_ros.rst
@@ -44,7 +44,7 @@ When this service is called, the response returns the current parameters for the
 
 An object is added to PyBullet.
 The service allows you to either load from file or pass the configuration for the object.
-The input for the service expects a ``ros_pybullet_interface/PybulletObject`` message - see `here <https://github.com/cmower/ros_pybullet_interface/blob/main/ros_pybullet_interface/msg/PybulletObject.msg>`_.
+The input for the service expects a ``ros_pybullet_interface/PybulletObject`` message - see `here <https://github.com/ros-pybullet/ros_pybullet_interface/blob/main/ros_pybullet_interface/msg/PybulletObject.msg>`_.
 
 For both cases (i.e. load from filename or configuration), an ``object_type`` must be given.
 Either ``PybulletObject.VISUAL``, ``PybulletObject.COLLISION``, ``PybulletObject.DYNAMIC``, ``PybulletObject.ROBOT``, ``PybulletObject.SOFT``, or ``PybulletObject.URDF``.

--- a/doc/develop.rst
+++ b/doc/develop.rst
@@ -7,8 +7,8 @@ Contributing
 ------------
 
 We are more than happy to accept bug fixes, new features, suggestions, comments, or any other form of feedback.
-If you have an issue using the interface, or would like a new feature added please `submit an issue <https://github.com/cmower/ros_pybullet_interface/issues>`_.
-For pull requests, please `fork the repository <https://github.com/cmower/ros_pybullet_interface/fork>`_, create a new branch, and submit your pull request.
+If you have an issue using the interface, or would like a new feature added please `submit an issue <https://github.com/ros-pybullet/ros_pybullet_interface/issues>`_.
+For pull requests, please `fork the repository <https://github.com/ros-pybullet/ros_pybullet_interface/fork>`_, create a new branch, and submit your pull request.
 
 Future work
 -----------

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -3,7 +3,7 @@
 Examples
 ========
 
-The examples for the ROS-PyBullet Interface are collected in a dedicated ROS package `rpbi_examples <https://github.com/cmower/ros_pybullet_interface/tree/main/rpbi_examples>`_.
+The examples for the ROS-PyBullet Interface are collected in a dedicated ROS package `rpbi_examples <https://github.com/ros-pybullet/ros_pybullet_interface/tree/main/rpbi_examples>`_.
 The following gives details for each example and shows how to run them.
 
 Basic Examples
@@ -14,15 +14,15 @@ Basic Examples
    $ roslaunch basic_example_[NAME].launch
 
 The basic examples simply demonstrate the current robots that can be loaded into PyBullet out-of-the-box.
-Each example loads the given robot, and `a node <https://github.com/cmower/ros_pybullet_interface/blob/main/rpbi_examples/scripts/basic_robot_example_node.py>`_ that generates a standardized motion on the robot.
+Each example loads the given robot, and `a node <https://github.com/ros-pybullet/ros_pybullet_interface/blob/main/rpbi_examples/scripts/basic_robot_example_node.py>`_ that generates a standardized motion on the robot.
 Some of the basic examples demonstrate different features of the library (e.g. recording a video, loading a URDF from the ROS parameter ``robot_description``).
 The following list links to the launch file for all the currently available basic examples.
 
-* `Kuka LWR <https://github.com/cmower/ros_pybullet_interface/blob/main/rpbi_examples/launch/basic_example_kuka_lwr.launch>`_
-* `Talos <https://github.com/cmower/ros_pybullet_interface/blob/main/rpbi_examples/launch/basic_example_talos.launch>`_
-* `Kinova <https://github.com/cmower/ros_pybullet_interface/blob/main/rpbi_examples/launch/basic_example_kinova.launch>`_
-* `Human model <https://github.com/cmower/ros_pybullet_interface/blob/main/rpbi_examples/launch/basic_example_human_model.launch>`_
-* `Nextage <https://github.com/cmower/ros_pybullet_interface/blob/main/rpbi_examples/launch/basic_example_nextage.launch>`_
+* `Kuka LWR <https://github.com/ros-pybullet/ros_pybullet_interface/blob/main/rpbi_examples/launch/basic_example_kuka_lwr.launch>`_
+* `Talos <https://github.com/ros-pybullet/ros_pybullet_interface/blob/main/rpbi_examples/launch/basic_example_talos.launch>`_
+* `Kinova <https://github.com/ros-pybullet/ros_pybullet_interface/blob/main/rpbi_examples/launch/basic_example_kinova.launch>`_
+* `Human model <https://github.com/ros-pybullet/ros_pybullet_interface/blob/main/rpbi_examples/launch/basic_example_human_model.launch>`_
+* `Nextage <https://github.com/ros-pybullet/ros_pybullet_interface/blob/main/rpbi_examples/launch/basic_example_nextage.launch>`_
 
 *Note*, the Kuka LWR example additionally demonstrates how to start recording videos and also how to attach a Force-Torque sensor to a robot joint.  
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -34,7 +34,7 @@ From source
 
 1. `Create a catkin workspace <https://catkin-tools.readthedocs.io/en/latest/quick_start.html#initializing-a-new-workspace>`_ or use an existing workspace. `catkin_tools <https://catkin-tools.readthedocs.io/en/latest/>`_ is the preferred build system.
 2. ``cd`` to the ``src`` directory of your catkin workspace.
-3. Clone this repository: ``$ git clone https://github.com/cmower/ros_pybullet_interface.git``
+3. Clone this repository: ``$ git clone https://github.com/ros-pybullet/ros_pybullet_interface.git``
 4. Install source dependencies: ``$ rosinstall . --catkin --nobuild``
 5. Install binary dependencies: ``$ rosdep update ; rosdep install --from-paths ./ -iry``
 6. Compile the workspace: ``$ catkin build -s``

--- a/doc/main_configuration.rst
+++ b/doc/main_configuration.rst
@@ -45,8 +45,8 @@ The benefit for this style-guide is that it allows you to easily tell the differ
 Furthermore, for the ``camelCase`` functions/parameters, you can look these up in the `PyBullet Quickstart Guide <https://docs.google.com/document/d/10sXEhzFRSnvFcl3XxNGhnD4N2SedqwdAvK3dsihxVUA/edit#heading=h.2ye70wns7io3>`_.
 Note, there are some exceptions to the rules however these are documented when necessary.
 
-Our basic "hello world example" is launched using `basic_example_kuka_lwr.launch <https://github.com/cmower/ros_pybullet_interface/blob/main/rpbi_examples/launch/basic_example_kuka_lwr.launch>`_.
-The main configuration file, `config.yaml <https://github.com/cmower/ros_pybullet_interface/blob/main/rpbi_examples/configs/basic_example_kuka_lwr/config.yaml>`_, is given as follows.
+Our basic "hello world example" is launched using `basic_example_kuka_lwr.launch <https://github.com/ros-pybullet/ros_pybullet_interface/blob/main/rpbi_examples/launch/basic_example_kuka_lwr.launch>`_.
+The main configuration file, `config.yaml <https://github.com/ros-pybullet/ros_pybullet_interface/blob/main/rpbi_examples/configs/basic_example_kuka_lwr/config.yaml>`_, is given as follows.
 
 .. code-block:: yaml
 

--- a/ros_pybullet_interface/src/rpbi/pybullet_robot_joints.py
+++ b/ros_pybullet_interface/src/rpbi/pybullet_robot_joints.py
@@ -80,7 +80,7 @@ class Joint:
     def ft_sensor_enabled(self):
         return self.ft_pub_key is not None
 
-    def publish_wrench(self, joint_reaction_forces):
+    def publish_wrench(self, joint_reaction_forces, frame_id):
         msg = WrenchStamped()
         msg.header.stamp = self.pb_obj.node.time_now()
         msg.wrench.force.x = joint_reaction_forces[0]
@@ -89,6 +89,8 @@ class Joint:
         msg.wrench.torque.x = joint_reaction_forces[3]
         msg.wrench.torque.y = joint_reaction_forces[4]
         msg.wrench.torque.z = joint_reaction_forces[5]
+        msg.header.stamp = self.pb_obj.node.time_now()
+        msg.header.frame_id = frame_id
         self.pb_obj.pubs[self.ft_pub_key].publish(msg)
 
 class Joints(list):
@@ -270,7 +272,7 @@ class Joints(list):
         # Publish ft sensor states
         for joint, joint_state in zip(self, joint_states):
             if joint.ft_sensor_enabled:
-                joint.publish_wrench(joint_state[2])
+                joint.publish_wrench(joint_state[2], joint.linkName)
 
         # Publish joint state message
         self.pb_obj.pubs['joint_state'].publish(self.pack_joint_state_msg(joint_states))


### PR DESCRIPTION
This is just a small change to add frame_id and time stamp when publishing the wrenches.

We need this in order to visualize (in rviz) the frame where the wrench applies to.

Just check and comment, do not merge it yet.
From the visualization i think that the force signs are reversed.
I'll check that tomorrow with the robot to make sure it's correct.

What i mean is, in order to be consistent with a force sensor on a robot, it should read as the force is being externally applied.
For me it seems that it is outputting the internal force instead, which is not what we want. But let me confirm this better.